### PR TITLE
Fix "master" missing error

### DIFF
--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -146,4 +146,5 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           github_token: '${{ secrets.COMMITTER_TOKEN }}'
-          pr_label: "automerge"  
+          pr_label: "automerge"
+          destination_branch: "main"


### PR DESCRIPTION
We don't use the branch